### PR TITLE
[개발] 광고-요청 API : 신청 가능한 위치(자리) 조회

### DIFF
--- a/src/main/java/com/pangoapi/common/CommonDefinition.java
+++ b/src/main/java/com/pangoapi/common/CommonDefinition.java
@@ -4,6 +4,9 @@ import java.util.regex.Pattern;
 
 public class CommonDefinition {
 
+    /** Advertisement layouts */
+    public static final int ADVERTISEMENT_LAYOUT_SIZE = 6;
+
     /** Image files */
     public static final String ALLOWABLE_MAXIMUM_IMAGE_FILE_SIZE_STRING = "20MiB";
     public static final Long ALLOWABLE_MAXIMUM_IMAGE_FILE_SIZE_LONG = (long) 20 * 1000 * 1000;

--- a/src/main/java/com/pangoapi/controller/advertisementRequest/AdvertisementRequestApiController.java
+++ b/src/main/java/com/pangoapi/controller/advertisementRequest/AdvertisementRequestApiController.java
@@ -2,7 +2,6 @@ package com.pangoapi.controller.advertisementRequest;
 
 import com.pangoapi.dto.ApiResponse;
 import com.pangoapi.dto.advertisementRequest.CreateDtoAdvertisementRequest;
-import com.pangoapi.dto.advertisement.RetrieveDtoAdvertisement;
 import com.pangoapi.dto.advertisementRequest.RetrieveDtoAdvertisementRequest;
 import com.pangoapi.dto.advertisementRequest.UpdateDtoAdvertisementRequest;
 import com.pangoapi.service.advertisementRequest.AdvertisementRequestService;
@@ -14,9 +13,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -50,6 +51,18 @@ public class AdvertisementRequestApiController {
         List<RetrieveDtoAdvertisementRequest> allRetrieveDtoAdvertisementRequests = advertisementRequestService.retrieveAllAdvertisementRequest();
 
         return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), allRetrieveDtoAdvertisementRequests);
+    }
+
+    @GetMapping("/api/v1/advertisement-requests/seats")
+    public ApiResponse retrieveAllPossibleSeats(@RequestParam("page") String page, @RequestParam("startedDate") String startedDate, @RequestParam("startedDate") String finishedDate) throws Exception{
+        List<String[]> allPossibleSeats = advertisementRequestService.retrieveAllPossibleSeats(
+                new HashMap<String, String>() {{
+                    put("page", page);
+                    put("startedDate", startedDate);
+                    put("finishedDate", finishedDate);
+                }});
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), allPossibleSeats);
     }
 
     /**

--- a/src/main/java/com/pangoapi/repository/advertisement/AdvertisementRepository.java
+++ b/src/main/java/com/pangoapi/repository/advertisement/AdvertisementRepository.java
@@ -2,5 +2,22 @@ package com.pangoapi.repository.advertisement;
 
 import com.pangoapi.domain.entity.advertisement.Advertisement;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface AdvertisementRepository extends JpaRepository<Advertisement, Long> { }
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public interface AdvertisementRepository extends JpaRepository<Advertisement, Long> {
+    @Query(value =
+            "SELECT new Map(adt.type as advertisementType, ad.rowPosition as rowPostion, ad.columnPosition as columnPosition) " +
+            "FROM Advertisement ad join ad.advertisementType adt " +
+            "WHERE :startedDate <= ad.finishedDate AND :finishedDate >= ad.startedDate AND ad.rowPosition >= CONVERT(:startIndexOfPage, UNSIGNED) AND ad.rowPosition <= CONVERT(:lastIndexOfPage, UNSIGNED)")
+    List<Map<String, String>> findAllImpossibleSeats(
+            @Param("startIndexOfPage") String startIndexOfPage,
+            @Param("lastIndexOfPage") String lastIndexOfPage,
+            @Param("startedDate") LocalDate startedDate,
+            @Param("finishedDate") LocalDate finishedDate
+    );
+}

--- a/src/main/java/com/pangoapi/repository/advertisementRequest/AdvertisementRequestRepository.java
+++ b/src/main/java/com/pangoapi/repository/advertisementRequest/AdvertisementRequestRepository.java
@@ -2,6 +2,22 @@ package com.pangoapi.repository.advertisementRequest;
 
 import com.pangoapi.domain.entity.advertisementRequest.AdvertisementRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 public interface AdvertisementRequestRepository extends JpaRepository<AdvertisementRequest, Long> {
+    @Query(value =
+            "SELECT new Map(adt.type as advertisementType, adr.rowPosition as rowPosition, adr.columnPosition as columnPosition) " +
+            "FROM AdvertisementRequest adr join adr.advertisementType adt " +
+            "WHERE :startedDate <= adr.finishedDate AND :finishedDate >= adr.startedDate AND adr.rowPosition >= CONVERT(:startIndexOfPage, UNSIGNED) AND adr.rowPosition <= CONVERT(:lastIndexOfPage, UNSIGNED)")
+    List<Map<String, String>> findAllImpossibleSeats(
+            @Param("startIndexOfPage") String startIndexOfPage,
+            @Param("lastIndexOfPage") String lastIndexOfPage,
+            @Param("startedDate") LocalDate startedDate,
+            @Param("finishedDate") LocalDate finishedDate
+    );
 }


### PR DESCRIPTION
**[개발] 광고-요청 API : 신청 가능한 위치(자리) 조회**

1. (광고 신청 페이지에서 사용될) 신청 가능한 위치를 조회하는 API를 개발합니다.
- 신청할 광고의 시작 날짜, 끝 날짜, **페이지 번호**가 input으로 입력됩니다.
- 해당 조건에 비어있는 위치(자리)를 배열 형태로 return 합니다.

Closes #20 