### PR TITLE
[개발] '로그인한 사용자'의 email 조회 API 개발 (using Cookie)

### DIFF
--- a/src/main/java/com/pangoapi/_common/exception/CommonExceptionHandler.java
+++ b/src/main/java/com/pangoapi/_common/exception/CommonExceptionHandler.java
@@ -5,6 +5,7 @@ import jdk.nashorn.internal.runtime.regexp.joni.exception.InternalException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,6 +28,18 @@ public class CommonExceptionHandler {
                 this.getClass() + "." + Thread.currentThread().getStackTrace()[1].getMethodName() + "\n\t"
                 + e.getClass() + ": " + e.getMessage() + "(" + e.getStackTrace()[0].toString() + ")"
         );
+    }
+
+    /**
+     * handleMissingRequestCookieException(MissingRequestCookieException.class)
+     * 목적 : API 요청에서 필수로 요구되는 쿠키가 없을 경우
+     * */
+    @ExceptionHandler(MissingRequestCookieException.class)
+    protected ResponseEntity<ApiResponse> handleMissingRequestCookieException(MissingRequestCookieException e) {
+        printCommonExceptionHandlerMessage(e);
+
+        ApiResponse response = ApiResponse.of(HttpStatus.BAD_REQUEST, "적절하지 않은 요청입니다. (Please check the cookie '" + e.getCookieName() + "')");
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     /**

--- a/src/main/java/com/pangoapi/_config/auth/CustomWebSecurityConfiguration.java
+++ b/src/main/java/com/pangoapi/_config/auth/CustomWebSecurityConfiguration.java
@@ -42,6 +42,7 @@ public class CustomWebSecurityConfiguration extends WebSecurityConfigurerAdapter
         // 3. http.csrf().ignoringAntMatchers("path");
 
         http.csrf().ignoringAntMatchers("/api/v1/**");
+        http.csrf().ignoringAntMatchers("/api/v2/**");
 
         http.authorizeRequests()
                 .antMatchers("/admin/**").authenticated()

--- a/src/main/java/com/pangoapi/user/controller/UserApiController.java
+++ b/src/main/java/com/pangoapi/user/controller/UserApiController.java
@@ -1,12 +1,16 @@
 package com.pangoapi.user.controller;
 
 import com.pangoapi._common.dto.ApiResponse;
+import com.pangoapi._common.utility.JwtProvider;
 import com.pangoapi.user.dto.CreateDtoUser;
 import com.pangoapi.user.dto.RetrieveDtoUser;
 import com.pangoapi.user.dto.UpdateDtoUser;
 import com.pangoapi.user.service.UserService;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +26,7 @@ import java.util.List;
 @RestController
 public class UserApiController {
 
+    private final JwtProvider jwtProvider;
     private final UserService userService;
 
     /**
@@ -40,6 +45,16 @@ public class UserApiController {
     @GetMapping("/api/v1/users/{userId}")
     public ApiResponse retrieveOneUser(@PathVariable("userId") Long _userId) {
         RetrieveDtoUser retrieveDtoUser = userService.retrieveOneUser(_userId);
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), retrieveDtoUser);
+    }
+
+    @GetMapping("/api/v1/login-users")
+    public ApiResponse retrieveOneUserByToken(@CookieValue("jwt") String token) {
+        Claims payload = jwtProvider.getPayloadFromToken(token);
+        String userEmail = payload.getAudience();
+
+        RetrieveDtoUser retrieveDtoUser = userService.retrieveOneUserByEmail(userEmail);
 
         return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), retrieveDtoUser);
     }

--- a/src/main/java/com/pangoapi/user/service/UserService.java
+++ b/src/main/java/com/pangoapi/user/service/UserService.java
@@ -61,6 +61,12 @@ public class UserService {
         return RetrieveDtoUser.createRetrieveDtoUser(user);
     }
 
+    public RetrieveDtoUser retrieveOneUserByEmail(String email) {
+        User user = userRepository.findUserByEmail(email).orElseThrow(() -> new EntityNotFoundException("해당 데이터를 조회할 수 없습니다."));
+
+        return RetrieveDtoUser.createRetrieveDtoUser(user);
+    }
+
     public List<RetrieveDtoUser> retrieveAllUser() {
         List<User> users = userRepository.findAll();
 


### PR DESCRIPTION
### [개발] '로그인한 사용자'의 email 조회 API 개발 (using Cookie)

1. 로그인한 User의 email 을 조회할 수 있는 API 개발 : /api/v1/login-users
2. ExceptionHandler 추가 : MissingRequestCookieException

<br>
Closes #70
