### PR TITLE
[개발] Poster-Request API 개발 (Advertisement-Request 대체, By adblock)

### DIFF
--- a/src/main/java/com/pangoapi/_common/enums/PosterReviewStatus.java
+++ b/src/main/java/com/pangoapi/_common/enums/PosterReviewStatus.java
@@ -1,0 +1,5 @@
+package com.pangoapi._common.enums;
+
+public enum PosterReviewStatus {
+    APPROVAL, NON_APPROVAL, PENDING
+}

--- a/src/main/java/com/pangoapi/posterRequest/controller/PosterRequestApiController.java
+++ b/src/main/java/com/pangoapi/posterRequest/controller/PosterRequestApiController.java
@@ -1,0 +1,147 @@
+package com.pangoapi.posterRequest.controller;
+
+import com.pangoapi._common.dto.ApiResponse;
+import com.pangoapi._common.exception.BadRequestException;
+import com.pangoapi.posterRequest.dto.CreateDtoPosterRequest;
+import com.pangoapi.posterRequest.dto.RetrieveDtoPosterRequest;
+import com.pangoapi.posterRequest.dto.UpdateDtoPosterRequest;
+import com.pangoapi.posterRequest.service.PosterRequestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static com.pangoapi._common.CommonDefinition.POSTER_LAYOUT_SIZE;
+
+@RequiredArgsConstructor
+@RestController
+public class PosterRequestApiController {
+
+    private final PosterRequestService posterRequestService;
+
+    /**
+     * CREATE
+     * */
+    @PostMapping("/api/v1/poster-requests")
+    public ApiResponse createPosterRequest(@RequestBody CreateDtoPosterRequest createDtoPosterRequest) throws Exception {
+        // 1. 요청이 들어온 Poster-Request 가 '신청 가능한 자리' 에 있는지 확인합니다.
+        // 1-1. 현재 '신청 가능한 모든 자리' 를 조회합니다.
+        int intTypeOfPage = Integer.parseInt(createDtoPosterRequest.getColumnPosition()) / POSTER_LAYOUT_SIZE + 1;
+        if(Integer.parseInt(createDtoPosterRequest.getColumnPosition()) % POSTER_LAYOUT_SIZE == 0) {
+            intTypeOfPage -= 1;
+        }
+        String page = Integer.toString(intTypeOfPage);
+        String startedDate = createDtoPosterRequest.getStartedDate();
+        String finishedDate = createDtoPosterRequest.getFinishedDate();
+
+        List<String[]> allPossibleSeats = posterRequestService.retrieveAllPossibleSeats(
+                new HashMap<String, String>() {{
+                    put("page", page);
+                    put("startedDate", startedDate);
+                    put("finishedDate", finishedDate);
+                }});
+
+        // 1-2. '신청 가능한 모든 자리' 와 '요청이 들어온 자리' 와 비교하여 신청이 가능한지 확인합니다.
+        if(!PosterRequestService.isPossibleSeat(
+                allPossibleSeats,
+                Long.parseLong(createDtoPosterRequest.getRowPosition()),
+                Long.parseLong(createDtoPosterRequest.getColumnPosition()),
+                createDtoPosterRequest.getPosterType())) {
+            throw new BadRequestException("이미 사용 중인 자리입니다. (Please check the position, possible-seats)");
+        }
+
+        // 2. 신청이 가능하다면, Poster-Request 를 생성합니다.
+        Long posterRequestId = posterRequestService.createPosterRequest(createDtoPosterRequest);
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), posterRequestId);
+    }
+
+    /**
+     * RETRIEVE
+     * */
+    @GetMapping("/api/v1/poster-requests/{posterRequestId}")
+    public ApiResponse retrievePosterRequest(@PathVariable("posterRequestId") Long _posterRequestId) {
+        com.pangoapi.posterRequest.dto.RetrieveDtoPosterRequest retrieveDtoPosterRequest = posterRequestService.retrievePosterRequest(_posterRequestId);
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), retrieveDtoPosterRequest);
+    }
+
+    @GetMapping("/api/v1/poster-requests")
+    public ApiResponse retrieveAllPosterRequests(@RequestParam("page") Optional<String> page) {
+        HashMap<String, String> retrieveOptions = new HashMap<>();
+        if(page.isPresent()) {
+            if (page.get().equalsIgnoreCase("0")) {
+                retrieveOptions.put("page", "1");
+            } else {
+                retrieveOptions.put("page", page.get());
+            }
+        }
+
+        List<com.pangoapi.posterRequest.dto.RetrieveDtoPosterRequest> allRetrieveDtoPosterRequests = posterRequestService.retrieveAllPosterRequests(retrieveOptions);
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), allRetrieveDtoPosterRequests);
+    }
+
+    @GetMapping("/api/v2/poster-requests")
+    public ApiResponse retrieveAllPosterRequests(@RequestParam("page") Optional<String> page,
+                                                       @RequestParam("userEmail") Optional<String> userEmail,
+                                                       @RequestParam("isFilteredDate") Optional<String> isFilteredDate) {
+        HashMap<String, String> retrieveCondition = new HashMap<>();
+
+        if(page.isPresent()) retrieveCondition.put("page", page.get());
+        else retrieveCondition.put("page", null);
+
+        if(userEmail.isPresent()) retrieveCondition.put("userEmail", userEmail.get());
+        else retrieveCondition.put("userEmail", null);
+
+        if(isFilteredDate.isPresent()) retrieveCondition.put("isFilteredDate", isFilteredDate.get());
+        else retrieveCondition.put("isFilteredDate", null);
+
+        List<RetrieveDtoPosterRequest> allRetrieveDtoPosterRequests = posterRequestService.retrieveAllPosterRequests_v2(retrieveCondition);
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), allRetrieveDtoPosterRequests);
+    }
+
+    @GetMapping("/api/v1/poster-requests/seats")
+    public ApiResponse retrieveAllPossibleSeats(@RequestParam("page") String page, @RequestParam("startedDate") String startedDate, @RequestParam("finishedDate") String finishedDate) throws Exception{
+        List<String[]> allPossibleSeats = posterRequestService.retrieveAllPossibleSeats(
+                new HashMap<String, String>() {{
+                    put("page", page);
+                    put("startedDate", startedDate);
+                    put("finishedDate", finishedDate);
+                }});
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), allPossibleSeats);
+    }
+
+    /**
+     * UPDATE
+     * */
+    @PutMapping("/api/v1/poster-requests/{posterRequestId}")
+    public ApiResponse updatePosterRequest(@PathVariable("posterRequestId") Long _posterRequestId, @RequestBody UpdateDtoPosterRequest updateDtoPosterRequest) throws Exception {
+        Long posterRequestId = posterRequestService.updatePosterRequest(_posterRequestId, updateDtoPosterRequest);
+
+        return new ApiResponse(HttpStatus.OK.value(), HttpStatus.OK.getReasonPhrase(), posterRequestId);
+    }
+
+    /**
+     * DELETE
+     * */
+    @DeleteMapping("/api/v1/poster-requests/{posterRequestId}")
+    public ApiResponse deletePosterRequest(@PathVariable("posterRequestId") Long _posterRequestId) {
+        posterRequestService.deletePosterRequest(_posterRequestId);
+
+        return new ApiResponse(HttpStatus.NO_CONTENT.value(), HttpStatus.NO_CONTENT.getReasonPhrase(), new ArrayList<>());
+    }
+}

--- a/src/main/java/com/pangoapi/posterRequest/dto/CreateDtoPosterRequest.java
+++ b/src/main/java/com/pangoapi/posterRequest/dto/CreateDtoPosterRequest.java
@@ -1,0 +1,23 @@
+package com.pangoapi.posterRequest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CreateDtoPosterRequest {
+
+    private String title;
+    private String userEmail;
+    private String description;
+    private String keywords;
+    private String posterType;
+    private String imagePath;
+    private String siteUrl;
+    private String rowPosition;
+    private String columnPosition;
+    private String startedDate;
+    private String finishedDate;
+}

--- a/src/main/java/com/pangoapi/posterRequest/dto/RetrieveConditionDtoPosterRequest.java
+++ b/src/main/java/com/pangoapi/posterRequest/dto/RetrieveConditionDtoPosterRequest.java
@@ -1,0 +1,52 @@
+package com.pangoapi.posterRequest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+import static com.pangoapi._common.CommonDefinition.POSTER_LAYOUT_SIZE;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+public class RetrieveConditionDtoPosterRequest {
+
+    String page;
+    String userEmail;
+
+    long startIndexOfPage = 1L;
+    long lastIndexOfPage = startIndexOfPage * POSTER_LAYOUT_SIZE;
+
+    LocalDate currentDate = LocalDate.now();
+
+    boolean isUnlimited = false;
+    boolean isFilteredDate = false;
+    boolean hasUserEmail = false;
+
+    public void isUnlimitedIsTrue() { this.isUnlimited = true; }
+
+    public void isUnlimitedIsFalse() { this.isUnlimited = false; }
+
+    public void isFilteredDateIsTrue() { this.isFilteredDate = true; }
+
+    public void isFilteredDateIsFalse() { this.isFilteredDate = false; }
+
+    public void hasUserEmailIsTrue() { this.hasUserEmail = true; }
+
+    public void hasUserEmailIsFalse() { this.hasUserEmail = false; }
+
+    public void pageIsDefault() { this.page = "1"; }
+
+    public void calculatePage() {
+        try {
+            startIndexOfPage = ((Long.parseLong(page) - 1) * POSTER_LAYOUT_SIZE) + 1;
+            lastIndexOfPage = (Long.parseLong(page) * POSTER_LAYOUT_SIZE);
+        } catch (NumberFormatException exception) {
+            throw new NumberFormatException("적절하지 않은 요청입니다. (Please check the page parameter)");
+        }
+    }
+}

--- a/src/main/java/com/pangoapi/posterRequest/dto/RetrieveDtoPosterRequest.java
+++ b/src/main/java/com/pangoapi/posterRequest/dto/RetrieveDtoPosterRequest.java
@@ -1,0 +1,49 @@
+package com.pangoapi.posterRequest.dto;
+
+import com.pangoapi.posterRequest.entity.PosterRequest;
+import com.pangoapi._common.enums.PosterReviewStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.format.DateTimeFormatter;
+
+@Builder
+@Getter
+public class RetrieveDtoPosterRequest {
+
+    private Long id;
+    private String userEmail;
+    private String title;
+    private String description;
+    private String keywords;
+    private String posterType;
+    private String posterWidth;
+    private String posterHeight;
+    private String imagePath;
+    private String siteUrl;
+    private String rowPosition;
+    private String columnPosition;
+    private PosterReviewStatus reviewStatus;
+    private String startedDate;
+    private String finishedDate;
+
+    public static com.pangoapi.posterRequest.dto.RetrieveDtoPosterRequest createRetrieveDtoPosterRequest(PosterRequest posterRequest) {
+        return RetrieveDtoPosterRequest.builder()
+                .id(posterRequest.getId())
+                .userEmail(posterRequest.getUser() != null ? posterRequest.getUser().getEmail() : "")
+                .title(posterRequest.getTitle())
+                .description(posterRequest.getDescription())
+                .keywords(posterRequest.getKeywords())
+                .posterType(posterRequest.getPosterType().getType())
+                .posterWidth(posterRequest.getPosterType().getWidth())
+                .posterHeight(posterRequest.getPosterType().getHeight())
+                .imagePath(posterRequest.getImagePath())
+                .siteUrl(posterRequest.getSiteUrl())
+                .rowPosition(Long.toString(posterRequest.getRowPosition()))
+                .columnPosition(Long.toString(posterRequest.getColumnPosition()))
+                .reviewStatus(posterRequest.getReviewStatus())
+                .startedDate(posterRequest.getStartedDate().format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .finishedDate(posterRequest.getFinishedDate().format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .build();
+    }
+}

--- a/src/main/java/com/pangoapi/posterRequest/dto/UpdateDtoPosterRequest.java
+++ b/src/main/java/com/pangoapi/posterRequest/dto/UpdateDtoPosterRequest.java
@@ -1,0 +1,21 @@
+package com.pangoapi.posterRequest.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateDtoPosterRequest {
+
+    private Long id;
+    private String userEmail;
+    private String title;
+    private String description;
+    private String keywords;
+    private String posterType;
+    private String imagePath;
+    private String siteUrl;
+    private String rowPosition;
+    private String columnPosition;
+    private Boolean reviewStatus;
+    private String startedDate;
+    private String finishedDate;
+}

--- a/src/main/java/com/pangoapi/posterRequest/entity/PosterRequest.java
+++ b/src/main/java/com/pangoapi/posterRequest/entity/PosterRequest.java
@@ -1,0 +1,178 @@
+package com.pangoapi.posterRequest.entity;
+
+import com.pangoapi.posterType.entity.PosterType;
+import com.pangoapi.posterRequest.dto.CreateDtoPosterRequest;
+import com.pangoapi.posterRequest.dto.UpdateDtoPosterRequest;
+import com.pangoapi.user.entity.User;
+import com.pangoapi._common.enums.PosterReviewStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+@Entity
+public class PosterRequest {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "POSTER_REQUEST_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "POSTER_TYPE_ID")
+    private PosterType posterType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "REVIEW_STATUS", length = 32)
+    private PosterReviewStatus reviewStatus;
+
+    @Column(length = 128)
+    private String title;
+
+    @Column(length = 255)
+    private String description;
+
+    @Column(length = 255)
+    private String keywords;
+
+    @Column(length = 128)
+    private String imagePath;
+
+    @Column(length = 255)
+    private String siteUrl;
+
+    @Column(length = 32)
+    private String reviewer;
+
+    private Long rowPosition;
+    private Long columnPosition;
+    private LocalDate startedDate;
+    private LocalDate finishedDate;
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeDescription(String description) {
+        this.description = description;
+    }
+
+    public void changeKeywords(String keywords) {
+        this.keywords = keywords;
+    }
+
+    public void changeImagePath(String imagePath) {
+        this.imagePath = imagePath;
+    }
+
+    public void changeStieUrl(String siteUrl) { this.siteUrl = siteUrl; }
+
+    public void changeRowPosition(Long rowPosition) { this.rowPosition = rowPosition; }
+
+    public void changeColumnPosition(Long columnPosition) { this.columnPosition = columnPosition; }
+
+    public void changeReviewStatusToApproval() { this.reviewStatus = PosterReviewStatus.APPROVAL; }
+
+    public void changeReviewStatusToPending() { this.reviewStatus = PosterReviewStatus.PENDING; }
+
+    public void changeReviewStatusToNonApproval() { this.reviewStatus = PosterReviewStatus.NON_APPROVAL; }
+
+    public void changeReviewer(String reviewer) { this.reviewer = reviewer; }
+
+    public void changeStartedDate(LocalDate startedDate) { this.startedDate = startedDate; }
+
+    public void changeFinishedDate(LocalDate finishedDate) { this.finishedDate = finishedDate; }
+
+    /**
+     * @description
+     * 사용자가 업데이트 요청할 수 있는 필드/메소드 입니다.
+     * 해당 메소드에 포함되지 않은 ReviewStatus, Reviewer 등의 필드는 관리자가 업데이트 요청할 수 있는 필드입니다. 즉, 관리자 관련 필드입니다.
+     * */
+    public void changePosterRequest(UpdateDtoPosterRequest updateDtoPosterRequest) throws Exception {
+        if(updateDtoPosterRequest.getTitle() != null) changeTitle(updateDtoPosterRequest.getTitle());
+        if(updateDtoPosterRequest.getDescription() != null) changeDescription(updateDtoPosterRequest.getDescription());
+        if(updateDtoPosterRequest.getKeywords() != null) changeKeywords(updateDtoPosterRequest.getKeywords());
+        if(updateDtoPosterRequest.getImagePath() != null) changeImagePath(updateDtoPosterRequest.getImagePath());
+        if(updateDtoPosterRequest.getSiteUrl() != null) changeStieUrl(updateDtoPosterRequest.getSiteUrl());
+        if(updateDtoPosterRequest.getRowPosition() != null) {
+            try {
+                changeRowPosition(Long.parseLong(updateDtoPosterRequest.getRowPosition()));
+            } catch (Exception exception) {
+                throw new Exception("적절하지 않은 요청입니다. (Please check the parameters)");
+            }
+        }
+        if(updateDtoPosterRequest.getColumnPosition() != null) {
+            try {
+                changeColumnPosition(Long.parseLong(updateDtoPosterRequest.getColumnPosition()));
+            } catch (Exception exception) {
+                throw new Exception("적절하지 않은 요청입니다. (Please check the parameters)");
+            }
+        }
+        if(updateDtoPosterRequest.getStartedDate() != null) {
+            try {
+                changeStartedDate(LocalDate.parse(updateDtoPosterRequest.getStartedDate()));
+            } catch (NullPointerException | DateTimeParseException exception) {
+                throw new IllegalArgumentException("적절하지 않은 날짜형식 입니다. (Please check the data 'startedDate')");
+            }
+        }
+        if(updateDtoPosterRequest.getFinishedDate() != null) {
+            try {
+                changeFinishedDate(LocalDate.parse(updateDtoPosterRequest.getFinishedDate()));
+            } catch (NullPointerException | DateTimeParseException exception) {
+                throw new IllegalArgumentException("적절하지 않은 날짜형식 입니다. (Please check the data 'finishedDate')");
+            }
+        }
+    }
+
+    public static PosterRequest createPosterRequest(CreateDtoPosterRequest createDtoPosterRequest, User user, PosterType posterType) throws Exception {
+        LocalDate startedDate = LocalDate.now(); LocalDate finishedDate = LocalDate.now().plusMonths(1);
+        Long rowPosition, columnPosition;
+        try {
+            rowPosition = Long.parseLong(createDtoPosterRequest.getRowPosition());
+            columnPosition = Long.parseLong(createDtoPosterRequest.getColumnPosition());
+
+            startedDate = LocalDate.parse(createDtoPosterRequest.getStartedDate());
+            finishedDate = LocalDate.parse(createDtoPosterRequest.getFinishedDate());
+        } catch (Exception exception) {
+            throw new Exception("적절하지 않은 요청입니다. (Please check the parameters)");
+        }
+
+        return PosterRequest.builder()
+                .id(null)
+                .user(user)
+                .posterType(posterType)
+                .reviewStatus(PosterReviewStatus.NON_APPROVAL)
+                .title(createDtoPosterRequest.getTitle())
+                .description(createDtoPosterRequest.getDescription())
+                .keywords(createDtoPosterRequest.getKeywords())
+                .imagePath(createDtoPosterRequest.getImagePath())
+                .siteUrl(createDtoPosterRequest.getSiteUrl())
+                .rowPosition(rowPosition)
+                .columnPosition(columnPosition)
+                .reviewer(null)
+                .startedDate(startedDate)
+                .finishedDate(finishedDate)
+                .build();
+    }
+}

--- a/src/main/java/com/pangoapi/posterRequest/repository/PosterRequestRepository.java
+++ b/src/main/java/com/pangoapi/posterRequest/repository/PosterRequestRepository.java
@@ -1,0 +1,29 @@
+package com.pangoapi.posterRequest.repository;
+
+import com.pangoapi.posterRequest.entity.PosterRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public interface PosterRequestRepository extends JpaRepository<PosterRequest, Long>, PosterRequestRepositoryCustom {
+    @Query(value =
+            "SELECT new Map(pt.type as posterType, pr.rowPosition as rowPosition, pr.columnPosition as columnPosition) " +
+            "FROM PosterRequest pr left join pr.posterType pt " +
+            "WHERE :startedDate <= pr.finishedDate AND :finishedDate >= pr.startedDate AND pr.columnPosition >= :startIndexOfPage AND pr.columnPosition <= :lastIndexOfPage")
+    List<Map<String, String>> findAllImpossibleSeats(
+            @Param("startIndexOfPage") Long startIndexOfPage,
+            @Param("lastIndexOfPage") Long lastIndexOfPage,
+            @Param("startedDate") LocalDate startedDate,
+            @Param("finishedDate") LocalDate finishedDate
+    );
+
+    @Query(value =
+            "SELECT pr " +
+            "FROM PosterRequest pr left join fetch pr.user " +
+            "WHERE pr.columnPosition >= :startIndexOfPage AND pr.columnPosition <= :lastIndexOfPage AND pr.startedDate <= DATE(NOW()) AND pr.finishedDate >= DATE(NOW())")
+    List<PosterRequest> findAllByPage(@Param("startIndexOfPage") Long startIndexOfPage, @Param("lastIndexOfPage") Long lastIndexOfPage);
+}

--- a/src/main/java/com/pangoapi/posterRequest/repository/PosterRequestRepositoryCustom.java
+++ b/src/main/java/com/pangoapi/posterRequest/repository/PosterRequestRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.pangoapi.posterRequest.repository;
+
+import com.pangoapi.posterRequest.dto.RetrieveConditionDtoPosterRequest;
+import com.pangoapi.posterRequest.entity.PosterRequest;
+
+import java.util.List;
+
+public interface PosterRequestRepositoryCustom {
+
+    List<PosterRequest> findAllByCondition(RetrieveConditionDtoPosterRequest retrieveConditionForPosterRequest);
+}

--- a/src/main/java/com/pangoapi/posterRequest/repository/PosterRequestRepositoryImpl.java
+++ b/src/main/java/com/pangoapi/posterRequest/repository/PosterRequestRepositoryImpl.java
@@ -1,0 +1,73 @@
+package com.pangoapi.posterRequest.repository;
+
+import com.pangoapi.posterRequest.dto.RetrieveConditionDtoPosterRequest;
+import com.pangoapi.posterRequest.entity.PosterRequest;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.pangoapi.posterRequest.entity.QPosterRequest.posterRequest;
+import static com.pangoapi.user.entity.QUser.user;
+
+public class PosterRequestRepositoryImpl implements PosterRequestRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public PosterRequestRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<PosterRequest> findAllByCondition(RetrieveConditionDtoPosterRequest condition) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 1. Page 조건을 가공합니다.
+        if(!condition.isUnlimited()) {
+            builder.and(goeColumnPosition(condition.getStartIndexOfPage()));
+            builder.and(loeColumnPosition(condition.getLastIndexOfPage()));
+        }
+
+        // 2. UserEmail 조건을 가공합니다.
+        if(condition.isHasUserEmail()) {
+            builder.and(eqUserEmail(condition.getUserEmail()));
+        }
+
+        // 3. IsFilteredDate 조건을 가공합니다.
+        if(condition.isFilteredDate()) {
+            builder.and(loeStartedDate(condition.getCurrentDate()));
+            builder.and(goeFinishedDate(condition.getCurrentDate()));
+        }
+
+        return jpaQueryFactory
+                .select(posterRequest)
+                .from(posterRequest)
+                .leftJoin(posterRequest.user, user).fetchJoin()
+                .where(builder)
+                .fetch();
+    }
+
+    private BooleanExpression loeColumnPosition(Long indexOfPage) {
+        return (indexOfPage != null) ? posterRequest.columnPosition.loe(indexOfPage) : null;
+    }
+
+    private BooleanExpression goeColumnPosition(Long indexOfPage) {
+        return (indexOfPage != null) ? posterRequest.columnPosition.goe(indexOfPage) : null;
+    }
+
+    private BooleanExpression loeStartedDate(LocalDate localDate) {
+        return (localDate != null) ? posterRequest.startedDate.loe(localDate) : null;
+    }
+
+    private BooleanExpression goeFinishedDate(LocalDate localDate) {
+        return (localDate != null) ? posterRequest.finishedDate.goe(localDate) : null;
+    }
+
+    private BooleanExpression eqUserEmail(String userEmail) {
+        return (userEmail != null) ? user.email.eq(userEmail) : null;
+    }
+}

--- a/src/main/java/com/pangoapi/posterRequest/service/PosterRequestService.java
+++ b/src/main/java/com/pangoapi/posterRequest/service/PosterRequestService.java
@@ -1,0 +1,307 @@
+package com.pangoapi.posterRequest.service;
+
+import com.pangoapi.poster.repository.PosterRepository;
+import com.pangoapi.posterType.entity.PosterType;
+import com.pangoapi.posterRequest.dto.CreateDtoPosterRequest;
+import com.pangoapi.posterRequest.dto.RetrieveConditionDtoPosterRequest;
+import com.pangoapi.posterRequest.dto.RetrieveDtoPosterRequest;
+import com.pangoapi.posterRequest.dto.UpdateDtoPosterRequest;
+import com.pangoapi.posterRequest.entity.PosterRequest;
+import com.pangoapi.posterRequest.repository.PosterRequestRepository;
+import com.pangoapi.user.entity.User;
+import com.pangoapi.posterType.repository.PosterTypeRepository;
+import com.pangoapi.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.EntityNotFoundException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.pangoapi._common.CommonDefinition.POSTER_LAYOUT_SIZE;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PosterRequestService {
+
+    private final UserRepository userRepository;
+    private final PosterRepository posterRepository;
+    private final PosterTypeRepository posterTypeRepository;
+    private final PosterRequestRepository posterRequestRepository;
+
+    private static final int POSSIBLE_SEAT = 1;
+    private static final int IMPOSSIBLE_SEAT = -1;
+
+    /**
+     * CREATE
+     */
+    @Transactional
+    public Long createPosterRequest(CreateDtoPosterRequest createDtoPosterRequest) throws Exception {
+        User user = userRepository.findUserByEmail(createDtoPosterRequest.getUserEmail()).orElse(null);
+        PosterType posterType = posterTypeRepository.findPosterTypeByType(createDtoPosterRequest.getPosterType()).orElseThrow(() -> new EntityNotFoundException("해당 데이터를 조회할 수 없습니다."));
+
+        Long posterRequestId = null;
+        try {
+            posterRequestId = posterRequestRepository.save(PosterRequest.createPosterRequest(createDtoPosterRequest, user, posterType)).getId();
+        } catch (DataIntegrityViolationException exception) {
+            throw new DataIntegrityViolationException("적절하지 않은 요청입니다. (Please check the data. This is usually related to SQL errors.)");
+        }
+
+        return posterRequestId;
+    }
+
+    /**
+     * RETRIEVE
+     */
+    public RetrieveDtoPosterRequest retrievePosterRequest(Long _posterRequestId) {
+        PosterRequest posterRequest = posterRequestRepository.findById(_posterRequestId).orElseThrow(() -> new EntityNotFoundException("해당 데이터를 조회할 수 없습니다."));
+
+        return RetrieveDtoPosterRequest.createRetrieveDtoPosterRequest(posterRequest);
+    }
+
+    public List retrieveAllPosterRequests(HashMap<String, String> retrieveOptions) {
+        Long startIndexOfPage = 1L, lastIndexOfPage = Long.valueOf(POSTER_LAYOUT_SIZE);
+        boolean isUnlimited = false;
+
+        try {
+            if(retrieveOptions.containsKey("page")) {
+                if(retrieveOptions.get("page").equalsIgnoreCase("-1")) {
+                    isUnlimited = true;
+                }
+                else {
+                    startIndexOfPage = (Long.parseLong(retrieveOptions.get("page")) - 1) * POSTER_LAYOUT_SIZE + 1;
+                    lastIndexOfPage = Long.parseLong(retrieveOptions.get("page")) * POSTER_LAYOUT_SIZE;
+                }
+            }
+        } catch (Exception exception) {
+            throw new IllegalArgumentException("적절하지 않은 요청입니다. (Please check the parameters)");
+        }
+
+        List<PosterRequest> posterRequests;
+        if(isUnlimited == true) {
+            posterRequests = posterRequestRepository.findAll();
+        }
+        else {
+            posterRequests = posterRequestRepository.findAllByPage(startIndexOfPage, lastIndexOfPage);
+        }
+
+        return posterRequests.stream().map(posterRequest -> RetrieveDtoPosterRequest.createRetrieveDtoPosterRequest(posterRequest)).collect(Collectors.toList());
+    }
+    
+    public List retrieveAllPosterRequests_v2(HashMap<String, String> retrieveCondition) {
+        RetrieveConditionDtoPosterRequest condition = new RetrieveConditionDtoPosterRequest();
+        
+        // 1. Page 정보를 가공합니다.
+        if(StringUtils.hasText(retrieveCondition.get("page"))) {
+            if(retrieveCondition.get("page").equalsIgnoreCase("-1")) {
+                condition.isUnlimitedIsTrue();
+                
+            }
+            else if (retrieveCondition.get("page").equalsIgnoreCase("0")) {
+                condition.isUnlimitedIsFalse();
+                condition.pageIsDefault();
+            }
+            else {
+                condition.isUnlimitedIsFalse();
+                condition.setPage(retrieveCondition.get("page"));
+                condition.calculatePage();
+            }
+        }
+        else {
+            condition.isUnlimitedIsFalse();
+            condition.pageIsDefault();
+        }
+        
+        // 2. UserEmail 정보를 가공합니다.
+        if(StringUtils.hasText(retrieveCondition.get("userEmail"))) {
+            condition.hasUserEmailIsTrue();
+            condition.setUserEmail(retrieveCondition.get("userEmail"));
+        }
+        else {
+            condition.hasUserEmailIsFalse();
+        }
+        
+        // 3. IsFilteredDate 정보를 가공합니다.
+        if(StringUtils.hasText(retrieveCondition.get("isFilteredDate"))) {
+            if(retrieveCondition.get("isFilteredDate").equalsIgnoreCase("true") || 
+                    retrieveCondition.get("isFilteredDate").equalsIgnoreCase("y")) {
+                condition.isFilteredDateIsTrue();
+            }
+            else {
+                condition.isFilteredDateIsFalse();
+            }
+        }
+        else {
+            condition.isFilteredDateIsTrue();
+        }
+        
+        List<PosterRequest> posterRequests = posterRequestRepository.findAllByCondition(condition);
+        
+        return posterRequests.stream().map(RetrieveDtoPosterRequest::createRetrieveDtoPosterRequest).collect(Collectors.toList());
+    }
+
+    public List<String[]> retrieveAllPossibleSeats(HashMap<String, String> wantedDate) throws Exception {
+        int[][] allSeats = new int[POSTER_LAYOUT_SIZE + 1][POSTER_LAYOUT_SIZE + 1];
+
+        Long startIndexOfPage, lastIndexOfPage;
+        LocalDate startedDate, finishedDate;
+
+        try {
+            startIndexOfPage = (Long.parseLong(wantedDate.get("page")) - 1) * POSTER_LAYOUT_SIZE + 1;
+            lastIndexOfPage = Long.parseLong(wantedDate.get("page")) * POSTER_LAYOUT_SIZE;
+            startedDate = LocalDate.parse(wantedDate.get("startedDate"));
+            finishedDate = LocalDate.parse(wantedDate.get("finishedDate"));
+        } catch (NullPointerException | DateTimeParseException | NumberFormatException exception) {
+            throw new IllegalArgumentException("적절하지 않은 데이터 형식 입니다. (Please check the data)");
+        }
+
+        List<Map<String, String>> impossibleSeats = posterRepository.findAllImpossibleSeats(startIndexOfPage, lastIndexOfPage, startedDate, finishedDate);
+        if (calculatePossibleSeats(allSeats, impossibleSeats) == false)
+            throw new Exception("신청 가능한 자리을 조회할 수 없습니다.");
+
+        impossibleSeats = posterRequestRepository.findAllImpossibleSeats(startIndexOfPage, lastIndexOfPage, startedDate, finishedDate);
+        if (calculatePossibleSeats(allSeats, impossibleSeats) == false)
+            throw new Exception("신청 가능한 자리를 조회할 수 없습니다.");
+
+        List<String[]> allPossibleSeats = getPossibleSeatsAsList(allSeats);
+
+        return allPossibleSeats;
+    }
+
+    /**
+     * UPDATE
+     */
+    @Transactional
+    public Long updatePosterRequest(Long _posterRequestId, UpdateDtoPosterRequest updateDtoPosterRequest) throws Exception {
+        PosterRequest posterRequest = posterRequestRepository.findById(_posterRequestId).orElseThrow(() -> new EntityNotFoundException("해당 데이터를 조회할 수 없습니다."));
+
+        posterRequest.changePosterRequest(updateDtoPosterRequest);
+
+        return posterRequest.getId();
+    }
+
+    /**
+     * DELETE
+     */
+    public void deletePosterRequest(Long _posterRequestId) {
+        posterRequestRepository.deleteById(_posterRequestId);
+    }
+
+    /**
+     * ETC
+     */
+    public boolean calculatePossibleSeats(int[][] allSeats, List<Map<String, String>> impossibleSeats) {
+        int[][] allSeatsCopy = new int[allSeats.length][allSeats[0].length];
+
+        for(int i = 0; i < allSeats.length; i++) {
+            for(int j = 0; j < allSeats[0].length; j++) {
+                allSeatsCopy[i][j] = allSeats[i][j];
+            }
+        }
+
+        try {
+            for (Map<String, String> impossibleSeat : impossibleSeats) {
+                String posterType = impossibleSeat.get("posterType");
+                int rowIndex = Integer.parseInt(String.valueOf(impossibleSeat.get("rowPosition")));
+                int columnIndex = Integer.parseInt(String.valueOf(impossibleSeat.get("columnPosition")));
+                int rangeOfIndex = posterType.charAt(1) - '0';
+
+                rowIndex = (rowIndex % POSTER_LAYOUT_SIZE);
+                columnIndex = (columnIndex % POSTER_LAYOUT_SIZE);
+                if(rowIndex == 0) rowIndex = POSTER_LAYOUT_SIZE;
+                if(columnIndex == 0) columnIndex = POSTER_LAYOUT_SIZE;
+
+                if (posterType.charAt(0) == 'R') {
+                    for (int i = 0; i < rangeOfIndex; i++) {
+                        allSeats[rowIndex + i][columnIndex] = IMPOSSIBLE_SEAT;
+                    }
+                }
+                else if (posterType.charAt(0) == 'C') {
+                    for (int i = 0; i < rangeOfIndex; i++) {
+                        allSeats[rowIndex][columnIndex + i] = IMPOSSIBLE_SEAT;
+                    }
+                }
+            }
+
+            return true;
+        } catch (Exception exception) {
+            System.out.println(exception);
+
+            // allSeats 배열을 초기화 합니다.
+            for(int i = 0; i < allSeats.length; i++) {
+                for(int j = 0; j < allSeats[0].length; j++) {
+                    allSeats[i][j] = allSeatsCopy[i][j];
+                }
+            }
+
+            return false;
+        }
+    }
+
+    public static boolean isPossibleSeat(List<String[]> allPossibleSeats, Long rowPosition, Long columnPosition, String stringTypeOfPosterType) {
+        boolean isPossible = true;
+
+        int[][] allSeats = new int[POSTER_LAYOUT_SIZE + 1][POSTER_LAYOUT_SIZE + 1];
+        int rangeOfIndex = stringTypeOfPosterType.charAt(1) - '0';
+        int rowIndex = Math.toIntExact(rowPosition);
+        int columnIndex = Math.toIntExact(columnPosition);
+
+        if(rowIndex > POSTER_LAYOUT_SIZE) {
+            rowIndex %= POSTER_LAYOUT_SIZE;
+            if(rowIndex == 0) rowIndex = POSTER_LAYOUT_SIZE;
+        }
+
+        if(columnIndex > POSTER_LAYOUT_SIZE) {
+            columnIndex %= POSTER_LAYOUT_SIZE;
+            if(columnIndex == 0) columnIndex = POSTER_LAYOUT_SIZE;
+        }
+
+        for (String[] allPossibleSeat: allPossibleSeats) {
+            allSeats[Integer.parseInt(allPossibleSeat[0])][Integer.parseInt(allPossibleSeat[1])] = POSSIBLE_SEAT;
+        }
+
+        if (stringTypeOfPosterType.charAt(0) == 'R') {
+            for (int i = 0; i < rangeOfIndex; i++) {
+                if((rowIndex + i > POSTER_LAYOUT_SIZE) ||
+                        (allSeats[rowIndex + i][columnIndex] != POSSIBLE_SEAT)) {
+                    isPossible = false;
+                    break;
+                }
+            }
+        }
+        else if (stringTypeOfPosterType.charAt(0) == 'C') {
+            for (int i = 0; i < rangeOfIndex; i++) {
+                if((columnIndex + i > POSTER_LAYOUT_SIZE) ||
+                        (allSeats[rowIndex][columnIndex + i] != POSSIBLE_SEAT)) {
+                    isPossible = false;
+                    break;
+                }
+            }
+        }
+
+        return isPossible;
+    }
+
+    public List<String[]> getPossibleSeatsAsList(int[][] allSeats) {
+        List<String[]> allPossibleSeats = new ArrayList<>();
+
+        for(int i = 1; i < allSeats.length; i++) {
+            for(int j = 1; j < allSeats[0].length; j++) {
+                if(allSeats[i][j] != IMPOSSIBLE_SEAT) {
+                    allPossibleSeats.add(new String[]{Integer.toString(i), Integer.toString(j)});
+                }
+            }
+        }
+
+        return allPossibleSeats;
+    }
+}

--- a/src/test/java/com/pangoapi/posterRequest/repository/PosterRequestRepositoryTest.java
+++ b/src/test/java/com/pangoapi/posterRequest/repository/PosterRequestRepositoryTest.java
@@ -1,0 +1,96 @@
+package com.pangoapi.posterRequest.repository;
+
+import com.pangoapi.posterRequest.dto.CreateDtoPosterRequest;
+import com.pangoapi.posterRequest.dto.RetrieveConditionDtoPosterRequest;
+import com.pangoapi.posterRequest.entity.PosterRequest;
+import com.pangoapi.posterType.entity.PosterType;
+import com.pangoapi.user.dto.CreateDtoUser;
+import com.pangoapi.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@DataJpaTest
+public class PosterRequestRepositoryTest {
+
+    @Autowired TestEntityManager entityManager;
+    @Autowired PosterRequestRepository posterRequestRepository;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        /**
+         * 1. Poster-Reuqest 더미 데이터 삽입
+         *  - User, PosterType 데이터 삽입 (or 조회)
+         *  - Position(rowPosition, columnPosition): [1,1], [1,2], [1,3], [1,4], [1,5], [1,6], [1,7]
+         * */
+
+        int numberOfDummyData = 7;
+
+        String title = "This is a title.";
+        String description = "This is a description.";
+        String keywords = "This is a keywords.";
+        String posterR1Type = "R1";
+        String imagePath = "This is a image path";
+        String siteUrl = "This is a site-url";
+        String userEmail = "test@email.com";
+        String startedDate = LocalDate.now().toString();
+        String finishedDate = LocalDate.now().plusMonths(1).toString();
+        Long rowPosition = 1L;
+        Long columnPosition = 1L;
+
+        User user = User.createUser(new CreateDtoUser(null, userEmail, null, null, null, null, null, null));
+        PosterType posterType = entityManager.find(PosterType.class, 1L);
+
+        entityManager.persist(user);
+
+
+        for(int i = 1; i < numberOfDummyData; i++, columnPosition++) {
+            entityManager.persist(PosterRequest.createPosterRequest(
+                    new CreateDtoPosterRequest(title, userEmail, description, keywords, posterR1Type, imagePath, siteUrl, Long.toString(rowPosition), Long.toString(columnPosition), startedDate, finishedDate),
+                    user,
+                    posterType
+            ));
+        }
+        entityManager.persist(PosterRequest.createPosterRequest(
+                new CreateDtoPosterRequest(title, userEmail, description, keywords, posterR1Type, imagePath, siteUrl, Long.toString(rowPosition), Long.toString(columnPosition), startedDate, finishedDate),
+                user,
+                posterType
+        ));
+
+        entityManager.flush();
+    }
+
+    /**
+     * Test: findAllByCondition()
+     * */
+    @Test
+    void When_call_findAllByCondition_Then_return_list_by_condition() {
+        // Given
+        int sizeOfPosterRequests = 1;
+        RetrieveConditionDtoPosterRequest condition = new RetrieveConditionDtoPosterRequest();
+
+        // 1. Page 정보를 설정합니다.
+        condition.setPage("2");
+        condition.calculatePage();
+        condition.isFilteredDateIsFalse();
+
+        // 2. UserEmail 정보를 설정합니다. (Must be "test@email.com")
+        condition.hasUserEmailIsTrue();
+        condition.setUserEmail("test@email.com");
+
+        // 3. IsFilteredDate 정보를 설정합니다.
+        condition.isFilteredDateIsTrue();
+
+        // When
+        List<PosterRequest> posterRequests = posterRequestRepository.findAllByCondition(condition);
+
+        // Then
+        Assertions.assertThat(posterRequests.size()).isEqualTo(sizeOfPosterRequests);
+    }
+}

--- a/src/test/java/com/pangoapi/posterRequest/service/PosterRequestServiceTest.java
+++ b/src/test/java/com/pangoapi/posterRequest/service/PosterRequestServiceTest.java
@@ -1,0 +1,227 @@
+package com.pangoapi.posterRequest.service;
+
+import com.pangoapi.poster.entity.Poster;
+import com.pangoapi.poster.repository.PosterRepository;
+import com.pangoapi.posterRequest.dto.CreateDtoPosterRequest;
+import com.pangoapi.posterRequest.entity.PosterRequest;
+import com.pangoapi.posterRequest.repository.PosterRequestRepository;
+import com.pangoapi.posterType.entity.PosterType;
+import com.pangoapi.posterType.repository.PosterTypeRepository;
+import com.pangoapi.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.pangoapi._common.CommonDefinition.POSTER_LAYOUT_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+@SpringBootTest(
+        classes = {
+                PosterRequestService.class
+        }
+)
+class PosterRequestServiceTest {
+
+    @Autowired PosterRequestService posterRequestService;
+
+    @MockBean UserRepository userRepository;
+    @MockBean PosterRepository posterRepository;
+    @MockBean PosterTypeRepository posterTypeRepository;
+    @MockBean PosterRequestRepository posterRequestRepository;
+
+    @Mock CreateDtoPosterRequest createDtoPosterRequest;
+    @Mock PosterRequest posterRequest;
+    @Mock PosterType posterType;
+
+    final int POSSIBLE_SEAT = 1;
+    final int IMPOSSIBLE_SEAT = -1;
+
+    @BeforeEach
+    public void setUp() {
+        // Configuration of PosterTypeRepository
+        Mockito.when(posterTypeRepository.findPosterTypeByType(any())).thenReturn(Optional.of(posterType));
+
+        // Configuration of PosterRequestRepository
+        Mockito.when(posterRequestRepository.save(any())).thenReturn(posterRequest);
+
+        // Configuration of PosterRequest
+        Mockito.when(posterRequest.getId()).thenReturn(1L);
+    }
+
+    /**
+     * Test (case1): createOnePosterRequest()
+     * */
+    @Test
+    public void When_call_createOnePosterRequest_Then_call_save() throws Exception {
+        // Given
+        Mockito.when(createDtoPosterRequest.getPosterType()).thenReturn("R1");
+        Mockito.when(createDtoPosterRequest.getRowPosition()).thenReturn("1");
+        Mockito.when(createDtoPosterRequest.getColumnPosition()).thenReturn("1");
+        Mockito.when(createDtoPosterRequest.getStartedDate()).thenReturn(String.valueOf(LocalDate.now()));
+        Mockito.when(createDtoPosterRequest.getFinishedDate()).thenReturn(String.valueOf(LocalDate.now().plusMonths(1)));
+
+        // When
+        posterRequestService.createPosterRequest(createDtoPosterRequest);
+
+        // Then
+        Mockito.verify(posterRequestRepository, times(1)).save(any(PosterRequest.class));
+    }
+
+    /**
+     * Test (case2): createOnePosterRequest()
+     * */
+    @Test
+    public void When_call_createOnePosterRequest_Then_check_possibleSeats() throws Exception {
+        // Given
+        Mockito.when(createDtoPosterRequest.getPosterType()).thenReturn("R1");
+        Mockito.when(createDtoPosterRequest.getRowPosition()).thenReturn("1");
+        Mockito.when(createDtoPosterRequest.getColumnPosition()).thenReturn("1");
+        Mockito.when(createDtoPosterRequest.getStartedDate()).thenReturn(String.valueOf(LocalDate.now()));
+        Mockito.when(createDtoPosterRequest.getFinishedDate()).thenReturn(String.valueOf(LocalDate.now().plusMonths(1)));
+
+        // When
+        posterRequestService.createPosterRequest(createDtoPosterRequest);
+
+        // Then
+        Mockito.verify(posterRequestRepository, times(1)).save(any(PosterRequest.class));
+    }
+
+    /**
+     * Test: retrieveAllPosterRequest_v2()
+     * */
+    @Test
+    public void When_call_retrieveAllPosterRequest_v2_Then_return_list() {
+        // Given
+        HashMap<String, String> retrieveCondition = new HashMap<>();
+        retrieveCondition.put("page", null);
+        retrieveCondition.put("userEmail", null);
+        retrieveCondition.put("isFilteredDate", null);
+
+        // When
+        List<Poster> posterList = posterRequestService.retrieveAllPosterRequests_v2(retrieveCondition);
+
+        // Then
+        assertThat(posterList.getClass()).isEqualTo(ArrayList.class);
+        Mockito.verify(posterRequestRepository, times(1)).findAllByCondition(any());
+    }
+
+    /**
+     * Test: getPossibleSeatsAsList()
+     * */
+    @Test
+    public void When_call_getPossibleSeatsAsList_Then_return_possibleSeatsAsList() throws Exception {
+        // Given
+        int[][] allPossibleSeats2D = new int[POSTER_LAYOUT_SIZE + 1][POSTER_LAYOUT_SIZE + 1];
+        for(int i = 1; i <= POSTER_LAYOUT_SIZE; i++) {
+            for(int j = 1; j <= POSTER_LAYOUT_SIZE; j++) {
+                allPossibleSeats2D[i][j] = IMPOSSIBLE_SEAT;
+            }
+        }
+
+        int possibleRowIndex = 1; int possibleColumnIndex = 1;
+        allPossibleSeats2D[possibleRowIndex][possibleColumnIndex] = POSSIBLE_SEAT;
+
+        // When
+        List<String[]> allPossibleSeatsAsList = posterRequestService.getPossibleSeatsAsList(allPossibleSeats2D);
+
+        // Then
+        assertThat(allPossibleSeatsAsList.get(0).length).isEqualTo(2);
+    }
+
+    /**
+     * Test: isPossibleSeat()
+     * */
+    @Test
+    public void When_call_isPossibleSeat_Then_check_possible_to_apply() {
+        // Given
+        int[][] allPossibleSeats2D = new int[POSTER_LAYOUT_SIZE + 1][POSTER_LAYOUT_SIZE + 1];
+        for(int i = 1; i <= POSTER_LAYOUT_SIZE; i++) {
+            for(int j = 1; j <= POSTER_LAYOUT_SIZE; j++) {
+                allPossibleSeats2D[i][j] = IMPOSSIBLE_SEAT;
+            }
+        }
+
+        int possibleRowIndex = 1; int possibleColumnIndex = 1;
+        allPossibleSeats2D[possibleRowIndex][possibleColumnIndex] = POSSIBLE_SEAT;
+
+        List<String[]> allPossibleSeatsAsList = posterRequestService.getPossibleSeatsAsList(allPossibleSeats2D);
+
+        // When
+        boolean isPossible = posterRequestService.isPossibleSeat(allPossibleSeatsAsList, 1L, 1L, "R1");
+        boolean isImpossible1 = posterRequestService.isPossibleSeat(allPossibleSeatsAsList, 1L, 2L, "R2");
+        boolean isImpossible2 = posterRequestService.isPossibleSeat(allPossibleSeatsAsList, 1L, 1L, "R2");
+
+        // Then
+        assertThat(isPossible).isEqualTo(true);
+        assertThat(isImpossible1).isEqualTo(false);
+        assertThat(isImpossible2).isEqualTo(false);
+    }
+
+    /**
+     * Test (case1): calculatePossibleSeats()
+     * */
+    @Test
+    public void When_call_calculatePossibleSeats_Then_calculate_possibleSeats_case1() {
+        // Given
+        int[][] allSeats = new int[POSTER_LAYOUT_SIZE + 1][POSTER_LAYOUT_SIZE + 1];
+        int impossibleRowIndex = 1; int impossibleColumnIndex = 1;
+        List<Map<String, String>> impossibleSeats = new ArrayList<>();
+        impossibleSeats.add(new HashMap<String, String>() {{
+            put("posterType", "R1");
+            put("rowPosition", String.valueOf(impossibleRowIndex));
+            put("columnPosition", String.valueOf(impossibleColumnIndex));
+        }});
+
+        // When
+        boolean resultOfCalculation = posterRequestService.calculatePossibleSeats(allSeats, impossibleSeats);
+
+        // Then
+        assertThat(resultOfCalculation).isEqualTo(true);
+        assertThat(allSeats[impossibleRowIndex][impossibleColumnIndex]).isEqualTo(-1);
+
+
+        impossibleSeats.add(new HashMap<String, String>() {{
+            put("posterType", "R6");
+            put("rowPosition", String.valueOf(impossibleRowIndex + 1));
+            put("columnPosition", String.valueOf(impossibleColumnIndex + 1));
+        }});
+        boolean resultOfCalculation2 = posterRequestService.calculatePossibleSeats(allSeats, impossibleSeats);
+        assertThat(resultOfCalculation2).isEqualTo(false);
+    }
+
+    /**
+     * Test (case2): calculatePossibleSeats()
+     * */
+    @Test
+    public void When_call_calculatePossibleSeats_Then_calculate_possibleSeats_case2() {
+        // Given
+        int[][] allSeats = new int[POSTER_LAYOUT_SIZE + 1][POSTER_LAYOUT_SIZE + 1];
+        int impossibleRowIndex = 1; int impossibleColumnIndex = 1;
+        List<Map<String, String>> impossibleSeats = new ArrayList<>();
+        impossibleSeats.add(new HashMap<String, String>() {{
+            put("posterType", "R6");
+            put("rowPosition", String.valueOf(impossibleRowIndex + 1));
+            put("columnPosition", String.valueOf(impossibleColumnIndex ));
+        }});
+
+        // When
+        boolean resultOfCalculation = posterRequestService.calculatePossibleSeats(allSeats, impossibleSeats);
+
+        // Then
+        assertThat(resultOfCalculation).isEqualTo(false);
+        assertThat(allSeats[impossibleRowIndex + 1][impossibleColumnIndex]).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
### [개발] Poster-Request API 개발 (Advertisement-Request 대체, By adblock)

1. Advertisement-Request API를 대체하기 위해, Poster-Request API 개발 (Advertisement 단어 대체)

<br>
Closes #78
