### PR TITLE
[개발] 인증메일 이미지 주소, 링크 수정

### DIFF
--- a/src/main/resources/templates/mails/verificationMailTemplate.html
+++ b/src/main/resources/templates/mails/verificationMailTemplate.html
@@ -6,8 +6,8 @@
 </head>
 <body style="text-align: center;">
 <header style="text-align: center;">
-    <a href="http://pango.com:8383/" target="_blank" style="text-decoration: none; color: #b6b6b6;">
-        <img src="https://gg-pigs.com/images/rhkdrhehowl.png" alt="pigs95team" width="128px" height="5%">
+    <a href="https://gg-pigs.com" target="_blank" style="text-decoration: none; color: #b6b6b6;">
+        <img src="https://raw.githubusercontent.com/pigs-pango-team/gg-pigs-image/main/images/logo.png" alt="pigs95team" width="128px" height="5%">
     </a>
 </header>
 <section style="text-align: center; margin-top: 2%">


### PR DESCRIPTION
### [개발] 인증메일 이미지 주소, 링크 수정

1. 인증메일에서 사용되는 이미지(로고)의 src, url 을 수정! 
 - gg-pigs.com
 - github image

<br>
Closes #110
