### PR TITLE
[개발] RestAPI 캐시 적용

### DIFF
--- a/src/main/java/com/gg_pigs/_common/CommonDefinition.java
+++ b/src/main/java/com/gg_pigs/_common/CommonDefinition.java
@@ -4,8 +4,11 @@ import java.util.regex.Pattern;
 
 public class CommonDefinition {
 
-    /** Advertisement layouts */
-    public static final int ADVERTISEMENT_LAYOUT_SIZE = 6;
+    /** Cache */
+    public static final int DEFAULT_CACHE_MAX_AGE = 30;
+    public static final int ZERO_CACHE_MAX_AGE = 0;
+
+    /** Poster layouts */
     public static final int POSTER_LAYOUT_SIZE = 6;
 
     /** Image files */

--- a/src/main/java/com/gg_pigs/_common/advice/CacheControllerAdvice.java
+++ b/src/main/java/com/gg_pigs/_common/advice/CacheControllerAdvice.java
@@ -17,10 +17,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.concurrent.TimeUnit;
 
+import static com.gg_pigs._common.CommonDefinition.DEFAULT_CACHE_MAX_AGE;
+
 @ControllerAdvice
 public class CacheControllerAdvice implements ResponseBodyAdvice {
-
-    private final int defaultCacheMaxAge = 30;
 
     @Override
     public boolean supports(MethodParameter returnType, Class converterType) {
@@ -39,7 +39,7 @@ public class CacheControllerAdvice implements ResponseBodyAdvice {
         String requestMethod = request.getMethod();
 
         if( requestMethod.equals(HttpMethod.GET.name()) && (responseStatus < HttpStatus.MULTIPLE_CHOICES.value()) ) {
-            response.setHeader(HttpHeaders.CACHE_CONTROL, CacheControl.maxAge(defaultCacheMaxAge, TimeUnit.SECONDS).getHeaderValue());
+            response.setHeader(HttpHeaders.CACHE_CONTROL, CacheControl.maxAge(DEFAULT_CACHE_MAX_AGE, TimeUnit.SECONDS).getHeaderValue());
         }
 
         return body;

--- a/src/main/java/com/gg_pigs/_common/advice/CacheControllerAdvice.java
+++ b/src/main/java/com/gg_pigs/_common/advice/CacheControllerAdvice.java
@@ -1,0 +1,47 @@
+package com.gg_pigs._common.advice;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.concurrent.TimeUnit;
+
+@ControllerAdvice
+public class CacheControllerAdvice implements ResponseBodyAdvice {
+
+    private final int defaultCacheMaxAge = 30;
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest serverHttpRequest, ServerHttpResponse serverHttpResponse) {
+        ServletServerHttpRequest servletServerHttpRequest = (ServletServerHttpRequest) serverHttpRequest;
+        ServletServerHttpResponse servletServerHttpResponse = (ServletServerHttpResponse) serverHttpResponse;
+
+        HttpServletRequest request = servletServerHttpRequest.getServletRequest();
+        HttpServletResponse response = servletServerHttpResponse.getServletResponse();
+
+        int responseStatus = response.getStatus();
+        String requestMethod = request.getMethod();
+
+        if( requestMethod.equals(HttpMethod.GET.name()) && (responseStatus < HttpStatus.MULTIPLE_CHOICES.value()) ) {
+            response.setHeader(HttpHeaders.CACHE_CONTROL, CacheControl.maxAge(defaultCacheMaxAge, TimeUnit.SECONDS).getHeaderValue());
+        }
+
+        return body;
+    }
+}

--- a/src/main/java/com/gg_pigs/_common/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/com/gg_pigs/_common/advice/ExceptionControllerAdvice.java
@@ -1,6 +1,8 @@
-package com.gg_pigs._common.exception;
+package com.gg_pigs._common.advice;
 
 import com.gg_pigs._common.dto.ApiResponse;
+import com.gg_pigs._common.exception.BadRequestException;
+import com.gg_pigs._common.exception.LoginFailureException;
 import jdk.nashorn.internal.runtime.regexp.joni.exception.InternalException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -21,7 +23,7 @@ import java.io.IOException;
  * */
 
 @ControllerAdvice
-public class CommonExceptionHandler {
+public class ExceptionControllerAdvice {
 
     private void printCommonExceptionHandlerMessage(Exception e) {
         System.out.println(

--- a/src/test/java/com/gg_pigs/_common/advice/CacheControllerAdviceTest.java
+++ b/src/test/java/com/gg_pigs/_common/advice/CacheControllerAdviceTest.java
@@ -19,6 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import static com.gg_pigs._common.CommonDefinition.DEFAULT_CACHE_MAX_AGE;
+import static com.gg_pigs._common.CommonDefinition.ZERO_CACHE_MAX_AGE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -32,9 +34,6 @@ class CacheControllerAdviceTest {
     @Autowired ObjectMapper objectMapper;
 
     @MockBean PosterService posterService;
-
-    private final int defaultCacheMaxAge = 30;
-    private final int zeroCacheMaxAge = 0;
 
     private CreateDtoPoster createDtoPoster;
     private UpdateDtoPoster updateDtoPoster;
@@ -62,7 +61,7 @@ class CacheControllerAdviceTest {
     @Test
     public void When_call_GET_method_Then_set_cache() throws Exception {
         // Given
-        String targetCacheControl = "max-age=" +  defaultCacheMaxAge;
+        String targetCacheControl = "max-age=" +  DEFAULT_CACHE_MAX_AGE;
 
         // When
         MockHttpServletResponse response = mockMvc.perform(get("/api/v2/posters"))
@@ -78,7 +77,7 @@ class CacheControllerAdviceTest {
     @Test
     public void When_call_POST_method_Then_set_cache_zero() throws Exception {
         // Given
-        String targetCacheControl = "max-age=" +  zeroCacheMaxAge;
+        String targetCacheControl = "max-age=" +  ZERO_CACHE_MAX_AGE;
 
         // When
         String content = objectMapper.writeValueAsString(createDtoPoster);
@@ -99,7 +98,7 @@ class CacheControllerAdviceTest {
     @Test
     public void When_call_PUT_method_Then_set_cache_zero() throws Exception {
         // Given
-        String targetCacheControl = "max-age=" +  zeroCacheMaxAge;
+        String targetCacheControl = "max-age=" +  ZERO_CACHE_MAX_AGE;
 
         // When
         String content = objectMapper.writeValueAsString(updateDtoPoster);
@@ -120,7 +119,7 @@ class CacheControllerAdviceTest {
     @Test
     public void When_call_DELETE_method_Then_set_cache_zero() throws Exception {
         // Given
-        String targetCacheControl = "max-age=" +  zeroCacheMaxAge;
+        String targetCacheControl = "max-age=" +  ZERO_CACHE_MAX_AGE;
 
         // When
         MockHttpServletResponse response = mockMvc.perform(delete("/api/v1/posters/1"))

--- a/src/test/java/com/gg_pigs/_common/advice/CacheControllerAdviceTest.java
+++ b/src/test/java/com/gg_pigs/_common/advice/CacheControllerAdviceTest.java
@@ -1,0 +1,135 @@
+package com.gg_pigs._common.advice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gg_pigs.poster.controller.PosterApiController;
+import com.gg_pigs.poster.dto.CreateDtoPoster;
+import com.gg_pigs.poster.dto.UpdateDtoPoster;
+import com.gg_pigs.poster.service.PosterService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+
+@WebMvcTest(value = PosterApiController.class)
+class CacheControllerAdviceTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockBean PosterService posterService;
+
+    private final int defaultCacheMaxAge = 30;
+    private final int zeroCacheMaxAge = 0;
+
+    private CreateDtoPoster createDtoPoster;
+    private UpdateDtoPoster updateDtoPoster;
+
+    private Long mockId = 1L;
+    private String mockTitle = "This is a title.";
+    private String mockUserEmail = "test@email.com";
+    private String mockDescription = "This is a detail description.";
+    private String mockKeywords = "This is a keywords.";
+    private String mockSlug = "This-is-a-title";
+    private String mockPosterType = "R1";
+    private String mockImagePath = "/src/image/exmaple.jpg";
+    private String mockSiteUrl = "siteUrl";
+    private String mockRowPosition = "1";
+    private String mockColumnPosition = "1";
+    private String mockStartedDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
+    private String mockFinishedDate = LocalDate.now().plusMonths(1).format(DateTimeFormatter.ISO_LOCAL_DATE);
+
+    @BeforeEach
+    void setUp() {
+        createDtoPoster = new CreateDtoPoster(mockTitle, mockUserEmail, mockDescription, mockKeywords, mockPosterType, mockImagePath, mockSiteUrl, mockRowPosition, mockColumnPosition, mockStartedDate, mockFinishedDate);
+        updateDtoPoster = new UpdateDtoPoster(mockId, mockUserEmail, mockTitle, mockDescription, mockKeywords, mockPosterType, mockImagePath, mockSiteUrl, mockRowPosition, mockColumnPosition, 'Y', mockStartedDate, mockFinishedDate);
+    }
+
+    @Test
+    public void When_call_GET_method_Then_set_cache() throws Exception {
+        // Given
+        String targetCacheControl = "max-age=" +  defaultCacheMaxAge;
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(get("/api/v2/posters"))
+                .andExpect(header().exists(HttpHeaders.CACHE_CONTROL))
+                .andReturn().getResponse();
+
+        // Then
+        String cacheControl = response.getHeader(HttpHeaders.CACHE_CONTROL);
+
+        Assertions.assertThat(cacheControl.contains(targetCacheControl)).isTrue();
+    }
+
+    @Test
+    public void When_call_POST_method_Then_set_cache_zero() throws Exception {
+        // Given
+        String targetCacheControl = "max-age=" +  zeroCacheMaxAge;
+
+        // When
+        String content = objectMapper.writeValueAsString(createDtoPoster);
+
+        MockHttpServletResponse response = mockMvc.perform(post("/api/v1/posters")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(content))
+                .andExpect(header().exists(HttpHeaders.CACHE_CONTROL))
+                .andReturn().getResponse();
+
+        // Then
+        String cacheControl = response.getHeader(HttpHeaders.CACHE_CONTROL);
+
+        Assertions.assertThat(cacheControl.contains(targetCacheControl)).isTrue();
+    }
+
+    @Test
+    public void When_call_PUT_method_Then_set_cache_zero() throws Exception {
+        // Given
+        String targetCacheControl = "max-age=" +  zeroCacheMaxAge;
+
+        // When
+        String content = objectMapper.writeValueAsString(updateDtoPoster);
+
+        MockHttpServletResponse response = mockMvc.perform(put("/api/v1/posters/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(content))
+                .andExpect(header().exists(HttpHeaders.CACHE_CONTROL))
+                .andReturn().getResponse();
+
+        // Then
+        String cacheControl = response.getHeader(HttpHeaders.CACHE_CONTROL);
+
+        Assertions.assertThat(cacheControl.contains(targetCacheControl)).isTrue();
+    }
+
+    @Test
+    public void When_call_DELETE_method_Then_set_cache_zero() throws Exception {
+        // Given
+        String targetCacheControl = "max-age=" +  zeroCacheMaxAge;
+
+        // When
+        MockHttpServletResponse response = mockMvc.perform(delete("/api/v1/posters/1"))
+                .andExpect(header().exists(HttpHeaders.CACHE_CONTROL))
+                .andReturn().getResponse();
+
+        // Then
+        String cacheControl = response.getHeader(HttpHeaders.CACHE_CONTROL);
+
+        Assertions.assertThat(cacheControl.contains(targetCacheControl)).isTrue();
+    }
+}


### PR DESCRIPTION
### [개발] RestAPI 캐시 적용

1. Max-Age 캐시 설정<br>
- Http Request Method 가 `GET` 이며, Http Response Status Code 가 2XX 대 인 경우에 cache 30초 설정합니다.
- 그 외에는 설정하지 않습니다.

<br>
Closes #121
